### PR TITLE
fix: notification error causing null return

### DIFF
--- a/api/src/Controllers/Notifications/NotificationsController.php
+++ b/api/src/Controllers/Notifications/NotificationsController.php
@@ -22,7 +22,7 @@ class NotificationsController
     {
         $notifications = Notification::where([
             ['user_id', '=', Flight::user()->id],
-        ])->limit(50)->get();
+        ])->limit(50)->get(true);
 
         Flight::json(
             NotificationsResource::collection($notifications)


### PR DESCRIPTION
# Description
Fix a notification error because it was returning null

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added (if applicable).
- [x] The code formatted (e.g. with `npm run format`)