### PR TITLE
fix: photo request returning object instead of array

### DIFF
--- a/api/src/Model/User.php
+++ b/api/src/Model/User.php
@@ -101,7 +101,7 @@ class User extends Model
             return null;
         }
 
-        return "http://" . (getenv('APP_HOST') ?? 'localhost') . ":3000/medias/p/" . $photo[0]->name;
+        return "http://" . (getenv('APP_HOST') ?? 'localhost') . ":3000/medias/p/" . $photo->name;
     }
 
     /**


### PR DESCRIPTION
# Description
Fix the issue where the photo request no longer returns an array but only an object

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added (if applicable).
- [x] The code formatted (e.g. with `npm run format`)