### PR TITLE
Fixed users without preferences or photos in the seeder.

### DIFF
--- a/api/src/Factory/PhotoFactory.php
+++ b/api/src/Factory/PhotoFactory.php
@@ -12,8 +12,10 @@ class PhotoFactory extends Factory
     {
         $name = $this->generatePhoto();
 
+        $user = $this->states['user'] ?? User::factory()->create();
+
         return [
-            'user_id' => User::factory()->create()->id,
+            'user_id' => $user->id,
             'name' => $name,
         ];
     }
@@ -29,10 +31,10 @@ class PhotoFactory extends Factory
         if ($this->userFaker) {
             $url = faker()->imageUrl();
         } else {
-            $photos = array_diff(
+            $photos = array_values(array_diff(
                 scandir(BASE_PATH . "/database/data_preset/photos/"),
                 [".", ".."] // For remove "." and ".." directory (errno=21)
-            );
+            ));
 
             $url = BASE_PATH
                 . "/database/data_preset/photos/"

--- a/api/src/Factory/PreferenceFactory.php
+++ b/api/src/Factory/PreferenceFactory.php
@@ -8,12 +8,12 @@ class PreferenceFactory extends Factory
 {
     protected function define(): array
     {
-        $newUser = User::factory()->create();
+        $user = $this->states['user'] ?? User::factory()->create();
 
         return [
-            "user_id" => $newUser->id,
-            "age_maximum" => rand($newUser->getAge(), 60),
-            "age_minimum" => rand(18, $newUser->getAge()),
+            "user_id" => $user->id,
+            "age_maximum" => rand($user->getAge(), 60),
+            "age_minimum" => rand(18, $user->getAge()),
             "sexual_preferences" => faker()->randomElement(['A', 'M', 'F', 'O']),
             "distance_maximum" => rand(1, 20),
             "by_tags" => (bool)rand(0, 1),

--- a/api/src/Model/User.php
+++ b/api/src/Model/User.php
@@ -245,10 +245,6 @@ class User extends Model
 
     public function getAge(): ?int
     {
-        if (is_null($this->birthday)) {
-            return null;
-        }
-
         $birthDate = explode("-", $this->birthday);
 
         return (date("md", date("U", mktime(0, 0, 0, $birthDate[2], $birthDate[1], $birthDate[0]))) > date("md")


### PR DESCRIPTION
# Description
- Fixed the photo warning caused by indexes 0 and 1 no longer existing (removed by `array_diff`).
- Fixed the issue where users without preferences or photos were generated, even though they shouldn't exist. Instead of generating 50 users (`php database/seeder.php -n 50`), we were generating three times as many.

# Checklist
The following items should be checked before the pull request can be merged.
- [x] Unit tests added (if applicable).
- [x] The code formatted (e.g. with `npm run format`)